### PR TITLE
Version 0.0.2 bump and CHANGELOG update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.0.2 - 2022-05-26 - Forward rather than reverse
+
+* Remove changes.reverse from apply so that things are applied in the octoDNS
+  best practice order: Deletes, Creates, Updates.
+
 ## v0.0.1 - 2022-01-11 - Moving
 
 #### Nothworthy Changes

--- a/octodns_gcore/__init__.py
+++ b/octodns_gcore/__init__.py
@@ -12,7 +12,7 @@ from octodns.record import GeoCodes, Record
 from octodns.provider import ProviderException
 from octodns.provider.base import BaseProvider
 
-__VERSION__ = '0.0.1'
+__VERSION__ = '0.0.2'
 
 
 class GCoreClientException(ProviderException):


### PR DESCRIPTION
## v0.0.2 - 2022-05-26 - Forward rather than reverse

* Remove changes.reverse from apply so that things are applied in the octoDNS
  best practice order: Deletes, Creates, Updates.