### PR TITLE
Add EdgeCenterProvider, refactor base class out children just hold urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-## Edge Center & G-Core Labs DNS v2 API provider for octoDNS
+## EdgeCenter DNS & G-Core Labs DNS v2 API provider for octoDNS
 
-An [octoDNS](https://github.com/octodns/octodns/) provider that targets [Edge Center](https://edgecenter.ru/dns/) and [G-Core Labs DNS](https://gcorelabs.com/dns/).
+An [octoDNS](https://github.com/octodns/octodns/) provider that targets [EdgeCenter DNS](https://edgecenter.ru/dns/) and [G-Core Labs DNS](https://gcorelabs.com/dns/).
 
 ### Installation
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-## G-Core Labs DNS v2 API provider for octoDNS
+## Edge Center & G-Core Labs DNS v2 API provider for octoDNS
 
-An [octoDNS](https://github.com/octodns/octodns/) provider that targets [G-Core Labs DNS](https://gcorelabs.com/dns/).
+An [octoDNS](https://github.com/octodns/octodns/) provider that targets [Edge Center](https://edgecenter.ru/dns/) and [G-Core Labs DNS](https://gcorelabs.com/dns/).
 
 ### Installation
 
@@ -32,6 +32,26 @@ octodns-gcore==0.0.1
 
 ### Configuration
 
+
+#### EdgeCenterProvider
+
+```
+providers:
+  ec:
+    class: octodns_gcore.EdgeCenterProvider
+    # Your API key
+    token: env/EC_TOKEN
+    token_type: APIKey
+    # or login + password
+    #login: env/EC_LOGIN
+    #password: env/EC_PASSWORD
+    #auth_url: https://api.edgecenter.ru/id
+    #url: https://api.edgecenter.ru/dns/v2
+    #records_per_response: 1
+```
+
+#### GCoreProvider
+
 ```yaml
 providers:
   gcore:
@@ -51,11 +71,11 @@ providers:
 
 #### Records
 
-GCoreProvider supports A, AAAA, NS, MX, TXT, SRV, CNAME, and PTR
+Supports A, AAAA, NS, MX, TXT, SRV, CNAME, and PTR
 
 #### Dynamic
 
-GCoreProvider supports dynamic records.
+Supports dynamic records.
 
 ### Development
 

--- a/octodns_gcore/__init__.py
+++ b/octodns_gcore/__init__.py
@@ -132,20 +132,17 @@ class GCoreClient(object):
         return base
 
 
-class GCoreProvider(BaseProvider):
+class _BaseProvider(BaseProvider):
     SUPPORTS_GEO = False
     SUPPORTS_DYNAMIC = True
     SUPPORTS = set(("A", "AAAA", "NS", "MX", "TXT", "SRV", "CNAME", "PTR"))
 
-    def __init__(self, id, *args, **kwargs):
+    def __init__(self, id, api_url, auth_url, *args, **kwargs):
         token = kwargs.pop("token", None)
         token_type = kwargs.pop("token_type", "APIKey")
         login = kwargs.pop("login", None)
         password = kwargs.pop("password", None)
-        api_url = kwargs.pop("url", "https://api.gcorelabs.com/dns/v2")
-        auth_url = kwargs.pop("auth_url", "https://api.gcorelabs.com/id")
         self.records_per_response = kwargs.pop("records_per_response", 1)
-        self.log = logging.getLogger(f"GCoreProvider[{id}]")
         self.log.debug("__init__: id=%s", id)
         super().__init__(id, *args, **kwargs)
         self._client = GCoreClient(
@@ -582,3 +579,19 @@ class GCoreProvider(BaseProvider):
         for change in changes:
             class_name = change.__class__.__name__
             getattr(self, f"_apply_{class_name.lower()}")(change)
+
+
+class EdgeCenterProvider(_BaseProvider):
+    def __init__(self, id, *args, **kwargs):
+        self.log = logging.getLogger(f"EdgeCenterProvider[{id}]")
+        api_url = kwargs.pop("url", "https://api.edgecenter.ru/dns/v2")
+        auth_url = kwargs.pop("auth_url", "https://api.edgecenter.ru/id")
+        super().__init__(id, api_url, auth_url, *args, **kwargs)
+
+
+class GCoreProvider(_BaseProvider):
+    def __init__(self, id, *args, **kwargs):
+        self.log = logging.getLogger(f"GCoreProvider[{id}]")
+        api_url = kwargs.pop("url", "https://api.gcorelabs.com/dns/v2")
+        auth_url = kwargs.pop("auth_url", "https://api.gcorelabs.com/id")
+        super().__init__(id, api_url, auth_url, *args, **kwargs)

--- a/tests/test_octodns_provider_gcore.py
+++ b/tests/test_octodns_provider_gcore.py
@@ -12,6 +12,8 @@ from octodns.provider.yaml import YamlProvider
 from octodns.zone import Zone
 
 from octodns_gcore import (
+    _BaseProvider,
+    EdgeCenterProvider,
     GCoreProvider,
     GCoreClientBadRequest,
     GCoreClientNotFound,
@@ -623,3 +625,10 @@ class TestGCoreProvider(TestCase):
                 ),
             ]
         )
+
+    def test_provider_hierarchy(self):
+        provider = GCoreProvider("test_id", token="token")
+        self.assertIsInstance(provider, _BaseProvider)
+
+        provider = EdgeCenterProvider("test_id", token="token")
+        self.assertIsInstance(provider, _BaseProvider)


### PR DESCRIPTION
Turn existing provider into an abstract base class from which `EdgeCenterProvider` and `GCoreProvider` can inherit. provider specific URLs are relocated to the child classes. 