### PR TITLE
Explicit strict_supports in tests

### DIFF
--- a/tests/test_octodns_provider_gcore.py
+++ b/tests/test_octodns_provider_gcore.py
@@ -186,7 +186,9 @@ class TestGCoreProvider(TestCase):
             )
 
     def test_apply(self):
-        provider = GCoreProvider("test_id", url="http://api", token="token")
+        provider = GCoreProvider(
+            "test_id", url="http://api", token="token", strict_supports=False
+        )
 
         # TC: Zone does not exists but can be created.
         with requests_mock() as mock:


### PR DESCRIPTION
As of https://github.com/octodns/octodns/pull/957 we'll need t be explicit in our tests around the expectations of `Provider.strict_supports`. This PR is in preparation of that change. 

/cc https://github.com/octodns/octodns/pull/957