### PR TITLE
Add root NS support.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.0.5 - 2023-12-xx - Root NS support
+
+* Add support for root NS updates
+
 ## v0.0.4 - 2023-04-27 - ALIAS support
 
 * add support for ALIAS as a CNAME at root

--- a/README.md
+++ b/README.md
@@ -53,7 +53,11 @@ providers:
 
 #### Records
 
-Supports A, AAAA, NS, MX, TXT, SRV, CNAME, and PTR
+Supports A, AAAA, ALIAS (CNAME flattening), NS, MX, TXT, SRV, CNAME, and PTR.
+CNAME flattening resolves both A and AAAA records and inherits the upstream TTL.
+
+#### Root NS Records
+The GCore provider supports full root NS record management.
 
 #### Dynamic
 

--- a/octodns_gcore/__init__.py
+++ b/octodns_gcore/__init__.py
@@ -151,6 +151,7 @@ class GCoreClient(object):
 class _BaseProvider(BaseProvider):
     SUPPORTS_GEO = False
     SUPPORTS_DYNAMIC = True
+    SUPPORTS_ROOT_NS = True
     SUPPORTS = set(
         ("A", "AAAA", "ALIAS", "CAA", "NS", "MX", "TXT", "SRV", "CNAME", "PTR")
     )

--- a/tests/test_octodns_provider_gcore.py
+++ b/tests/test_octodns_provider_gcore.py
@@ -257,8 +257,8 @@ class TestGCoreProvider(TestCase):
         plan = provider.plan(self.expected)
 
         # TC: create all
-        self.assertEqual(14, len(plan.changes))
-        self.assertEqual(14, provider.apply(plan))
+        self.assertEqual(15, len(plan.changes))
+        self.assertEqual(15, provider.apply(plan))
         self.assertFalse(plan.exists)
 
         provider._client._request.assert_has_calls(
@@ -288,6 +288,17 @@ class TestGCoreProvider(TestCase):
                         "ttl": 300,
                         "resource_records": [
                             {"content": [0, "issue", "ca.unit.tests"]}
+                        ],
+                    },
+                ),
+                call(
+                    "POST",
+                    "http://api/zones/unit.tests/unit.tests./NS",
+                    data={
+                        "ttl": 300,
+                        "resource_records": [
+                            {"content": ["ns1.gcorelabs.net."]},
+                            {"content": ["ns2.gcdn.services."]},
                         ],
                     },
                 ),
@@ -416,7 +427,7 @@ class TestGCoreProvider(TestCase):
             ]
         )
         # expected number of total calls
-        self.assertEqual(17, provider._client._request.call_count)
+        self.assertEqual(18, provider._client._request.call_count)
 
         # TC: delete 1 and update 1
         provider._client._request.reset_mock()


### PR DESCRIPTION
GCore supports root NS records out-of-the-box. Add the flag.

I have checked the changes against my private GCore account.

Fixes #48.